### PR TITLE
remove numpy version requirements

### DIFF
--- a/.github/workflows/test-basic.yaml
+++ b/.github/workflows/test-basic.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install XAutoDL from source
         run: |
-          python setup.py install
+          pip install .
 
       - name: Test Search Space
         run: |

--- a/.github/workflows/test-misc.yaml
+++ b/.github/workflows/test-misc.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install XAutoDL from source
         run: |
-          python setup.py install
+          pip install .
 
       - name: Test Xmisc
         run: |

--- a/.github/workflows/test-super-layer_model.yaml
+++ b/.github/workflows/test-super-layer_model.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install XAutoDL from source
         run: |
-          python setup.py install
+          pip install .
 
       - name: Test Super Model
         run: |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ At this moment, this project provides the following algorithms and scripts to ru
 ## Requirements and Preparation
 
 
-**First of all**, please use `python setup.py install` to install `xautodl` library.
+**First of all**, please use `pip install .` to install `xautodl` library.
 
 Please install `Python>=3.6` and `PyTorch>=1.5.0`. (You could use lower versions of Python and PyTorch, but may have bugs).
 Some visualization codes may require `opencv`.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def read(fname="README.md"):
 
 
 # What packages are required for this module to be executed?
-REQUIRED = ["numpy>=1.16.5,<=1.19.5", "pyyaml>=5.0.0", "fvcore"]
+REQUIRED = ["numpy>=1.16.5", "pyyaml>=5.0.0", "fvcore"]
 
 packages = find_packages(
     exclude=("tests", "scripts", "scripts-search", "lib*", "exps*")


### PR DESCRIPTION
Is it possible to remove numpy version requirements?

I want to use the benchmark, but my codes are relying on some new bug fixes after `numpy>1.20`.